### PR TITLE
Remove conflicts_with "telepresence" from telepresence-oss formula

### DIFF
--- a/Formula/telepresence-oss.rb
+++ b/Formula/telepresence-oss.rb
@@ -18,8 +18,6 @@ class TelepresenceOss < Formula
   # TODO support linux arm64
   #sha256 "__TARBALL_HASH_LINUX_ARM64__" if OS.linux? && Hardware::CPU.arm?
 
-  conflicts_with "telepresence"
-
   def install
       bin.install "#{PACKAGE_NAME}" => "telepresence"
   end


### PR DESCRIPTION
Hello, the "telepresence" formula does not exist in the main Homebrew repo and this is causing a warning on every install/upgrade as reported in https://github.com/telepresenceio/homebrew-telepresence/issues/1

Maybe this is a deliberate choice, but in case it isn't this PR removes the stale `conflicts_with` declaration.

Fixes https://github.com/telepresenceio/homebrew-telepresence/issues/1